### PR TITLE
Fix for issue when returning GString from etag closure

### DIFF
--- a/grails-app/services/grails/plugins/cacheheaders/CacheHeadersService.groovy
+++ b/grails-app/services/grails/plugins/cacheheaders/CacheHeadersService.groovy
@@ -170,7 +170,7 @@ class CacheHeadersService {
 				if (log.debugEnabled) {
 					log.debug "There was a list of ETag candidates supplied [${tagList}], calculated new ETag... ${etag}"
 				}
-				if (!tagList.contains(etag)) {
+				if (!tagList.contains(etag?.toString())) {
 					etagChanged = true
 				}
 			}


### PR DESCRIPTION
When returning GString from etag closure contains fails evaluation. Forced toString() execution before comparing