### PR TITLE
Remove @Autowired from CacheHeadersService in CacheHeadersTrait

### DIFF
--- a/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
+++ b/src/main/groovy/grails/plugins/cacheheaders/CacheHeadersTrait.groovy
@@ -1,13 +1,11 @@
 package grails.plugins.cacheheaders
 
-import org.springframework.beans.factory.annotation.*
 import grails.web.api.*
 import groovy.transform.*
 
 @CompileStatic
 trait CacheHeadersTrait extends ServletAttributes {
 
-	@Autowired
 	CacheHeadersService cacheHeadersService
 
 


### PR DESCRIPTION
@Autowired causes a BeanNotFoundException during client applicaiton unit tests (even if the cache methods are not used).